### PR TITLE
Use Jake Wharton's SDK gradle plugin to ensure we're all on the same set of build tools, SDK version and support libraries.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,14 @@
+apply plugin: 'android-sdk-manager'
 apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.0"
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
         applicationId "com.codepath.apps.restclienttemplate"
         minSdkVersion 16
-        targetSdkVersion 21
+        targetSdkVersion 23
     }
 
     buildTypes {

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,11 @@
 buildscript {
     repositories {
         jcenter()
+        maven { url 'https://jitpack.io' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.github.JakeWharton:sdk-manager-plugin:220bf7a88a7072df3ed16dc8466fb144f2817070'
     }
 }
 


### PR DESCRIPTION
@scottrichards - can you check out this branch and re-sync your gradle files to verify it works ok for you?

I followed this article that Nate sent out: http://guides.codepath.com/android/Installing-Android-SDK-Tools#installing-the-android-sdk-automated-way

to have the gradle plugin automatically keep us synced to the same SDK, build tools and support libraries. 

This fixed a project warning I was getting about our project not targeting the latest SDK and the build tools being out of date.
