### PR TITLE
Issue #3 - Create a fragment for pet details and a pet details activity that hosts it

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,13 +26,14 @@ repositories {
 
 dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
-    compile 'com.android.support:appcompat-v7:23.1.1'
     // Picasso for remote image loading
-    compile 'com.squareup.picasso:picasso:2.5.2'
     // Android Async Http for sending async network requests
-    compile 'com.loopj.android:android-async-http:1.4.9'
     // ActiveAndroid for simple persistence with an ORM
+    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.squareup.picasso:picasso:2.5.2'
+    compile 'com.loopj.android:android-async-http:1.4.9'
     compile 'com.michaelpardo:activeandroid:3.1.0-SNAPSHOT'
     compile 'com.jakewharton:butterknife:7.0.1'
     compile 'com.google.code.gson:gson:2.4'
+    compile 'com.android.support:design:23.1.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,14 @@
+apply plugin: 'android-sdk-manager'
 apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.0"
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
         applicationId "com.codepath.apps.restclienttemplate"
         minSdkVersion 16
-        targetSdkVersion 21
+        targetSdkVersion 23
     }
 
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "23.0.0"
 
     defaultConfig {
-        applicationId "com.codepath.apps.restclienttemplate"
+        applicationId "com.codepath.apps.critterfinder"
         minSdkVersion 16
         targetSdkVersion 21
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,4 +32,6 @@ dependencies {
     compile 'com.loopj.android:android-async-http:1.4.9'
     // ActiveAndroid for simple persistence with an ORM
     compile 'com.michaelpardo:activeandroid:3.1.0-SNAPSHOT'
+    compile 'com.jakewharton:butterknife:7.0.1'
+    compile 'com.google.code.gson:gson:2.4'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,21 +2,20 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.codepath.apps.critterfinder"
     android:versionCode="1"
-    android:versionName="1.0" >
-
-    <uses-sdk
-        android:minSdkVersion="16"
-        android:targetSdkVersion="21" />
+    android:versionName="1.0">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
     <application
-        android:name="com.codepath.apps.critterfinder.RestApplication"
+        android:name=".RestApplication"
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme" >
+        android:theme="@style/AppTheme">
         <meta-data
             android:name="AA_DB_NAME"
             android:value="RestClient.db" />
@@ -26,8 +25,8 @@
 
         <activity
             android:name=".FindActivity"
-            android:theme="@style/AppTheme"
-            android:label="@string/app_name" >
+            android:label="@string/app_name"
+            android:theme="@style/AppTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -43,6 +42,13 @@
                     android:host="cprest"
                     android:scheme="oauth" />
             </intent-filter>
+        </activity>
+        <activity
+            android:name=".activities.PetDetailsActivity"
+            android:label="@string/title_activity_pet_details"
+            android:theme="@style/AppTheme.NoActionBar">
+
+
         </activity>
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,8 +47,6 @@
             android:name=".activities.PetDetailsActivity"
             android:label="@string/title_activity_pet_details"
             android:theme="@style/AppTheme.NoActionBar">
-
-
         </activity>
     </application>
 

--- a/app/src/main/java/com/codepath/apps/critterfinder/activities/PetDetailsActivity.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/activities/PetDetailsActivity.java
@@ -1,0 +1,53 @@
+package com.codepath.apps.critterfinder.activities;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+
+import com.codepath.apps.critterfinder.R;
+import com.codepath.apps.critterfinder.fragments.PetDetailsFragment;
+import com.codepath.apps.critterfinder.models.PetModel;
+
+import butterknife.ButterKnife;
+
+public class PetDetailsActivity extends AppCompatActivity {
+
+    private static String EXTRA_PET = "com.codepath.apps.critterfinder.activities.details.pet";
+
+    /**
+     * Create an intent which will start the pet details activity
+     * @param context
+     * @param pet
+     * @return
+     */
+    public static Intent getStartIntent(Context context, PetModel pet) {
+        Intent intent= new Intent(context, PetDetailsActivity.class);
+        // TODO - once our pet model is parcelabe, work our magic
+        intent.putExtra(PetDetailsActivity.EXTRA_PET, "");
+        return intent;
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_pet_details);
+        ButterKnife.bind(this);
+
+        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+
+        if (savedInstanceState == null) {
+            // TODO - pass in the pet
+            setupPetDetails(null);
+        }
+    }
+
+    private void setupPetDetails(PetModel pet) {
+        PetDetailsFragment petDetailsFragment = PetDetailsFragment.newInstance(null);
+        getSupportFragmentManager().beginTransaction().
+                replace(R.id.layout_details_fragment_placeholder, petDetailsFragment).
+                commit();
+    }
+}

--- a/app/src/main/java/com/codepath/apps/critterfinder/fragments/PetDetailsFragment.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/fragments/PetDetailsFragment.java
@@ -1,0 +1,34 @@
+package com.codepath.apps.critterfinder.fragments;
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import com.codepath.apps.critterfinder.R;
+
+import butterknife.Bind;
+import butterknife.ButterKnife;
+
+/**
+ * Created by smacgregor on 2/29/16.
+ */
+public class PetDetailsFragment extends Fragment {
+
+    @Bind(R.id.text_pet_details) TextView mPetDetailsLabel;
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.fragment_pet_details, container, false);
+        ButterKnife.bind(this, view);
+
+        setupPetDetailsView();
+        return view;
+    }
+
+    private void setupPetDetailsView() {
+        mPetDetailsLabel.setText(getResources().getString(R.string.pet_details_description));
+    }
+}

--- a/app/src/main/java/com/codepath/apps/critterfinder/fragments/PetDetailsFragment.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/fragments/PetDetailsFragment.java
@@ -18,7 +18,7 @@ import butterknife.ButterKnife;
  */
 public class PetDetailsFragment extends Fragment {
 
-    private static final String ARGUMENT_PET = "ARGUMENT_USER_ID";
+    private static final String ARGUMENT_PET = "ARGUMENT_PET";
 
     @Bind(R.id.text_pet_details) TextView mPetDetailsLabel;
 

--- a/app/src/main/java/com/codepath/apps/critterfinder/fragments/PetDetailsFragment.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/fragments/PetDetailsFragment.java
@@ -8,6 +8,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import com.codepath.apps.critterfinder.R;
+import com.codepath.apps.critterfinder.models.PetModel;
 
 import butterknife.Bind;
 import butterknife.ButterKnife;
@@ -17,7 +18,19 @@ import butterknife.ButterKnife;
  */
 public class PetDetailsFragment extends Fragment {
 
+    private static final String ARGUMENT_PET = "ARGUMENT_USER_ID";
+
     @Bind(R.id.text_pet_details) TextView mPetDetailsLabel;
+
+    public static PetDetailsFragment newInstance(PetModel pet) {
+        PetDetailsFragment petDetailsFragment = new PetDetailsFragment();
+        Bundle args = new Bundle();
+
+        // TODO - once our pet model is parcelable wire it up
+        args.putString(ARGUMENT_PET, "");
+        petDetailsFragment.setArguments(args);
+        return petDetailsFragment;
+    }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {

--- a/app/src/main/res/layout/activity_pet_details.xml
+++ b/app/src/main/res/layout/activity_pet_details.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    tools:context="com.codepath.apps.critterfinder.activities.PetDetailsActivity">
+
+    <android.support.design.widget.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/AppTheme.AppBarOverlay">
+
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorPrimary"
+            app:popupTheme="@style/AppTheme.PopupOverlay" />
+
+    </android.support.design.widget.AppBarLayout>
+
+    <include layout="@layout/content_pet_details" />
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/pet_details_fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="@dimen/fab_margin"
+        android:src="@android:drawable/ic_dialog_email" />
+
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/content_pet_details.xml
+++ b/app/src/main/res/layout/content_pet_details.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior"
+    tools:context="com.codepath.apps.critterfinder.activities.PetDetailsActivity"
+    tools:showIn="@layout/activity_pet_details">
+
+    <FrameLayout
+        android:id="@+id/layout_details_fragment_placeholder"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+    </FrameLayout>
+</RelativeLayout>

--- a/app/src/main/res/layout/fragment_pet_details.xml
+++ b/app/src/main/res/layout/fragment_pet_details.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/text_pet_details"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+</RelativeLayout>

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -1,0 +1,9 @@
+<resources>>
+
+    <style name="AppTheme.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+    </style>
+</resources>

--- a/app/src/main/res/values-w820dp/dimens.xml
+++ b/app/src/main/res/values-w820dp/dimens.xml
@@ -1,0 +1,6 @@
+<resources>
+    <!-- Example customization of dimensions originally defined in res/values/dimens.xml
+         (such as screen margins) for screens with more than 820dp of available width. This
+         would include 7" and 10" devices in landscape (~960dp and ~1280dp respectively). -->
+    <dimen name="activity_horizontal_margin">64dp</dimen>
+</resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -3,5 +3,6 @@
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
+    <dimen name="fab_margin">16dp</dimen>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,7 @@
     <string name="app_name">Critter Finder</string>
     <string name="login_label">Log in</string>
 
+    <!-- Pet Details Strings -->
+    <string name="pet_details_description">Example text description. This is a great pet to adopt. Adopt me!</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,5 +6,6 @@
 
     <!-- Pet Details Strings -->
     <string name="pet_details_description">Example text description. This is a great pet to adopt. Adopt me!</string>
+    <string name="title_activity_pet_details">PetDetailsActivity</string>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -13,4 +13,13 @@
         <!-- All customizations that are NOT specific to a particular API-level can go here. -->
     </style>
 
+    <style name="AppTheme.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
+    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
+
+    <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
+
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,11 @@
 buildscript {
     repositories {
         jcenter()
+        maven { url 'https://jitpack.io' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.github.JakeWharton:sdk-manager-plugin:220bf7a88a7072df3ed16dc8466fb144f2817070'
     }
 }
 


### PR DESCRIPTION
https://github.com/TeamCritterFinder/CritterFinder/issues/3 - Scaffolding to support a pet details fragment which can be re-used throughout the app.

This PR is dirty and depends on https://github.com/TeamCritterFinder/CritterFinder/pull/2 and https://github.com/TeamCritterFinder/CritterFinder/issues/3.
1. Create a Pet Details Fragment and an associated fragment layout
2. Create a Pet Details Activity which hosts the fragment. We may not end up using this activity - but for now I need it as a way to test the fragment.
3. Create subpackages in the project for fragments, activities and adapters

Screen shot of the changes:

<img width="552" alt="screen shot 2016-02-29 at 11 20 48 pm" src="https://cloud.githubusercontent.com/assets/1521460/13420447/1bd7bda2-df3b-11e5-953d-ec0b66de3a9c.png">
