### PR TITLE
Skeleton code for supporting search filters

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'android-sdk-manager'
 apply plugin: 'com.android.application'
+apply plugin: 'com.neenbedankt.android-apt'
 
 android {
     compileSdkVersion 23
@@ -30,6 +31,8 @@ dependencies {
     // Android Async Http for sending async network requests
     // ActiveAndroid for simple persistence with an ORM
     compile 'com.android.support:appcompat-v7:23.1.1'
+    apt 'org.parceler:parceler:1.0.4'
+    compile 'org.parceler:parceler-api:1.0.4'
     compile 'com.squareup.picasso:picasso:2.5.2'
     compile 'com.loopj.android:android-async-http:1.4.9'
     compile 'com.michaelpardo:activeandroid:3.1.0-SNAPSHOT'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,12 @@
             android:theme="@style/AppTheme">
 
             <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+            <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -46,11 +52,6 @@
             android:name=".activities.PetBrowserActivity"
             android:label=""
             android:theme="@style/AppTheme.NoActionBar">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,12 +28,6 @@
             android:theme="@style/AppTheme">
 
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-
-            <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -50,8 +44,12 @@
             android:theme="@style/AppTheme.NoActionBar"></activity>
         <activity
             android:name=".activities.PetBrowserActivity"
-            android:label="@string/title_activity_pet_browser"
             android:theme="@style/AppTheme.NoActionBar">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
         </activity>
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,12 +6,11 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <application
-        android:name=".RestApplication"
+        android:name=".CritterFinderApplication"
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
@@ -27,11 +26,13 @@
             android:name=".FindActivity"
             android:label="@string/app_name"
             android:theme="@style/AppTheme">
+
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -46,6 +47,10 @@
         <activity
             android:name=".activities.PetDetailsActivity"
             android:label="@string/title_activity_pet_details"
+            android:theme="@style/AppTheme.NoActionBar"></activity>
+        <activity
+            android:name=".activities.PetBrowserActivity"
+            android:label="@string/title_activity_pet_browser"
             android:theme="@style/AppTheme.NoActionBar">
         </activity>
     </application>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,6 +44,7 @@
             android:theme="@style/AppTheme.NoActionBar"></activity>
         <activity
             android:name=".activities.PetBrowserActivity"
+            android:label=""
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/codepath/apps/critterfinder/CritterFinderApplication.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/CritterFinderApplication.java
@@ -7,20 +7,20 @@ import android.content.Context;
  * including the image cache in memory and on disk. This also adds a singleton
  * for accessing the relevant rest client.
  *
- *     RestClient client = RestApplication.getRestClient();
+ *     RestClient client = CritterFinderApplication.getRestClient();
  *     // use client to send requests to API
  *
  */
-public class RestApplication extends com.activeandroid.app.Application {
+public class CritterFinderApplication extends com.activeandroid.app.Application {
 	private static Context context;
 
 	@Override
 	public void onCreate() {
 		super.onCreate();
-		RestApplication.context = this;
+		CritterFinderApplication.context = this;
 	}
 
 	public static RestClient getRestClient() {
-		return (RestClient) RestClient.getInstance(RestClient.class, RestApplication.context);
+		return (RestClient) RestClient.getInstance(RestClient.class, CritterFinderApplication.context);
 	}
 }

--- a/app/src/main/java/com/codepath/apps/critterfinder/activities/PetBrowserActivity.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/activities/PetBrowserActivity.java
@@ -1,17 +1,24 @@
 package com.codepath.apps.critterfinder.activities;
 
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
+import android.support.v4.app.FragmentManager;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.view.Menu;
+import android.view.MenuItem;
 
 import com.codepath.apps.critterfinder.R;
+import com.codepath.apps.critterfinder.fragments.SearchFilterDialog;
 import com.codepath.apps.critterfinder.fragments.SwipeablePetsFragment;
+import com.codepath.apps.critterfinder.models.SearchFilter;
 
 import butterknife.ButterKnife;
 
-public class PetBrowserActivity extends AppCompatActivity {
+public class PetBrowserActivity extends AppCompatActivity implements SearchFilterDialog.OnSearchFilterFragmentInteractionListener {
 
     SwipeablePetsFragment mSwipeablePetsFragment;
+    SearchFilter mSearchFilter;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -22,6 +29,38 @@ public class PetBrowserActivity extends AppCompatActivity {
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
+        mSearchFilter = new SearchFilter();
         mSwipeablePetsFragment = (SwipeablePetsFragment) getSupportFragmentManager().findFragmentById(R.id.fragment_swipeable_pets_browser);
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.menu_pet_browser, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case R.id.menu_item_search:
+                showSearchFilterDialog();
+                return true;
+            // TODO - add support for loading the favorites fragment here
+            default:
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public void onFinishedSavingSearchFilter(SearchFilter searchFilter) {
+        mSearchFilter = searchFilter;
+        // TODO - fill this in to kick off a search against the criteria in searchFilter
+        Snackbar.make(findViewById(android.R.id.content), "Search filters have been updated. Gender: " + searchFilter.getGender().toString(), Snackbar.LENGTH_LONG).show();
+    }
+
+    private void showSearchFilterDialog() {
+        FragmentManager fragmentManager = getSupportFragmentManager();
+        SearchFilterDialog searchFilterDialog = SearchFilterDialog.newInstance(mSearchFilter);
+        searchFilterDialog.show(fragmentManager, "fragment_search_filter");
     }
 }

--- a/app/src/main/java/com/codepath/apps/critterfinder/activities/PetBrowserActivity.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/activities/PetBrowserActivity.java
@@ -1,0 +1,27 @@
+package com.codepath.apps.critterfinder.activities;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+
+import com.codepath.apps.critterfinder.R;
+import com.codepath.apps.critterfinder.fragments.SwipeablePetsFragment;
+
+import butterknife.ButterKnife;
+
+public class PetBrowserActivity extends AppCompatActivity {
+
+    SwipeablePetsFragment mSwipeablePetsFragment;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_pet_browser);
+        ButterKnife.bind(this);
+
+        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+
+        mSwipeablePetsFragment = (SwipeablePetsFragment) getSupportFragmentManager().findFragmentById(R.id.fragment_swipeable_pets_browser);
+    }
+}

--- a/app/src/main/java/com/codepath/apps/critterfinder/fragments/SearchFilterDialog.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/fragments/SearchFilterDialog.java
@@ -1,0 +1,110 @@
+package com.codepath.apps.critterfinder.fragments;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.DialogFragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.Button;
+import android.widget.Spinner;
+
+import com.codepath.apps.critterfinder.R;
+import com.codepath.apps.critterfinder.models.SearchFilter;
+
+import org.parceler.Parcels;
+
+import butterknife.Bind;
+import butterknife.ButterKnife;
+import butterknife.OnClick;
+import butterknife.OnItemSelected;
+
+/**
+ * Created by smacgregor on 3/3/16.
+ */
+public class SearchFilterDialog extends DialogFragment {
+
+    private static final String ARGUMENT_SEARCH_FILTER = "ARGUMENT_SEARCH_FILTER";
+    @Bind(R.id.spinner_gender) Spinner mGenderSpinner;
+
+    private SearchFilter mSearchFilter;
+    private OnSearchFilterFragmentInteractionListener mListener;
+
+    public static SearchFilterDialog newInstance(SearchFilter searchFilter) {
+        SearchFilterDialog searchFilterDialog = new SearchFilterDialog();
+        Bundle args = new Bundle();
+        args.putParcelable(ARGUMENT_SEARCH_FILTER, Parcels.wrap(searchFilter));
+        searchFilterDialog.setArguments(args);
+        return searchFilterDialog;
+    }
+
+    public SearchFilterDialog() {}
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            mSearchFilter = Parcels.unwrap(getArguments().getParcelable(ARGUMENT_SEARCH_FILTER));
+        }
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_search_filter_dialog, container, false);
+    }
+
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        ButterKnife.bind(this, view);
+
+        setupGenderSpinner();
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        if (activity instanceof OnSearchFilterFragmentInteractionListener) {
+            mListener = (OnSearchFilterFragmentInteractionListener) activity;
+        }
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        mListener = null;
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        ButterKnife.unbind(this);
+    }
+
+    @OnClick(R.id.button_save_search_filter)
+    void onSaveSearchFilterClicked(Button button) {
+        if (mListener != null) {
+            mListener.onFinishedSavingSearchFilter(mSearchFilter);
+        }
+        dismiss();
+    }
+
+    @OnItemSelected(R.id.spinner_gender)
+    void onGenderSelected(AdapterView<?> parent, View view, int position, long id) {
+        mSearchFilter.setGender(SearchFilter.Gender.values()[position]);
+    }
+    private void setupGenderSpinner() {
+        mGenderSpinner.setSelection(mSearchFilter.getGender().ordinal());
+    }
+
+    public interface OnSearchFilterFragmentInteractionListener {
+        /**
+         * The search filter has been updated
+         * @param searchFilter
+         */
+        void onFinishedSavingSearchFilter(SearchFilter searchFilter);
+    }
+}

--- a/app/src/main/java/com/codepath/apps/critterfinder/fragments/SwipeablePetsFragment.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/fragments/SwipeablePetsFragment.java
@@ -1,0 +1,63 @@
+package com.codepath.apps.critterfinder.fragments;
+
+import android.os.Bundle;
+import android.support.design.widget.Snackbar;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.codepath.apps.critterfinder.R;
+import com.squareup.picasso.Picasso;
+
+import butterknife.Bind;
+import butterknife.ButterKnife;
+import butterknife.OnClick;
+
+/**
+ * Our tinder-like pet browser
+ */
+public class SwipeablePetsFragment extends Fragment {
+
+    @Bind(R.id.text_pet_gender) TextView mPetGender;
+    @Bind(R.id.text_pet_name) TextView mPetName;
+    @Bind(R.id.image_pet) ImageView mPetImage;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // nothing to do here yet...
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        View currentView = inflater.inflate(R.layout.fragment_swipeable_pets, container, false);
+        ButterKnife.bind(this, currentView);
+
+        setupPet();
+        return currentView;
+    }
+
+    @OnClick(R.id.button_like)
+    public void onLikeButtonClicked(Button button) {
+        Snackbar.make(getActivity().findViewById(android.R.id.content), "Yeah you like this pet!", Snackbar.LENGTH_LONG).show();
+    }
+
+    @OnClick(R.id.button_pass)
+    public void onPassButtonClicked(Button button) {
+        Snackbar.make(getActivity().findViewById(android.R.id.content), "Keep trying the right pet is out there!", Snackbar.LENGTH_LONG).show();
+    }
+
+    private void setupPet() {
+        mPetName.setText("Bentley The Coton");
+        mPetGender.setText("Male");
+        Picasso.with(mPetImage.getContext()).
+                load("http://scontent.cdninstagram.com/t51.2885-15/s640x640/sh0.08/e35/12071062_736784449785114_1231793951_n.jpg").
+                into(mPetImage);
+    }
+}

--- a/app/src/main/java/com/codepath/apps/critterfinder/models/SearchFilter.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/models/SearchFilter.java
@@ -1,0 +1,58 @@
+package com.codepath.apps.critterfinder.models;
+
+import org.parceler.Parcel;
+
+/**
+ * Created by smacgregor on 3/3/16.
+ */
+@Parcel
+public class SearchFilter {
+
+    // TODO - should these enums be pulled outside of the search filter class
+    // so they can be leveraged by our pet models?
+
+    public enum Gender {
+        MALE("M"),
+        FEMALE("F");
+
+        private final String mName;
+
+        Gender(String name) {
+            mName = name;
+        }
+        public String toString() {
+            return this.mName;
+        }
+    }
+
+    public enum Size {
+        SMALL("S"),
+        MEDIUM("M"),
+        LARGE("L"),
+        XLARGE("XL");
+
+        private final String mName;
+
+        Size(String name) {
+            mName = name;
+        }
+        public String toString() {
+            return this.mName;
+        }
+    }
+
+    Gender mGender;
+    Size mSize;
+
+    public SearchFilter() {
+        mGender = Gender.MALE;
+    }
+
+    public Gender getGender() {
+        return mGender;
+    }
+
+    public void setGender(Gender gender) {
+        mGender = gender;
+    }
+}

--- a/app/src/main/res/layout/activity_pet_browser.xml
+++ b/app/src/main/res/layout/activity_pet_browser.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    tools:context="com.codepath.apps.critterfinder.activities.PetBrowserActivity">
+
+    <android.support.design.widget.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/AppTheme.AppBarOverlay">
+
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorPrimary"
+            app:popupTheme="@style/AppTheme.PopupOverlay" />
+
+    </android.support.design.widget.AppBarLayout>
+
+    <include layout="@layout/content_pet_browser" />
+
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/content_pet_browser.xml
+++ b/app/src/main/res/layout/content_pet_browser.xml
@@ -1,0 +1,9 @@
+<fragment xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/fragment_swipeable_pets_browser"
+    android:name="com.codepath.apps.critterfinder.fragments.SwipeablePetsFragment"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior"
+    tools:layout="@layout/fragment_swipeable_pets" />

--- a/app/src/main/res/layout/fragment_search_filter_dialog.xml
+++ b/app/src/main/res/layout/fragment_search_filter_dialog.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_gravity="center"
+    tools:context="com.codepath.apps.critterfinder.fragments.SearchFilterDialog"
+    android:padding="60dp">
+
+    <Spinner
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/spinner_gender"
+        android:layout_row="1"
+        android:layout_column="1"
+        android:spinnerMode="dialog"
+        android:entries="@array/gender_array"/>
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/filter_save"
+        android:id="@+id/button_save_search_filter"
+        android:layout_gravity="center_horizontal" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_swipeable_pets.xml
+++ b/app/src/main/res/layout/fragment_swipeable_pets.xml
@@ -6,47 +6,49 @@
     android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingRight="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
-    tools:context=".FindActivity" >
+    tools:context=".fragments.SwipeablePetsFragment"
+    tools:showIn="@layout/activity_pet_browser">
 
     <ImageView
         android:layout_width="match_parent"
         android:layout_height="300dp"
-        android:id="@+id/petImage"
-        />
+        android:scaleType="fitCenter"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"
+        android:id="@+id/image_pet"/>
 
     <TextView
-        android:layout_below="@id/petImage"
+        android:layout_below="@id/image_pet"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentLeft="true"
-        android:id="@+id/petSex"/>
+        android:id="@+id/text_pet_gender"/>
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginLeft="5dp"
-        android:layout_toRightOf="@id/petSex"
-        android:layout_below="@id/petImage"
+        android:layout_toRightOf="@id/text_pet_gender"
+        android:layout_below="@id/image_pet"
         android:text="Pet Name"
-        android:id="@+id/petName"/>
+        android:id="@+id/text_pet_name"/>
 
     <Button
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Pass"
         android:onClick="onDislike"
-        android:layout_below="@id/petName"
-        android:id="@+id/passBtn"
-        />
+        android:layout_below="@id/text_pet_name"
+        android:id="@+id/button_pass"/>
 
     <Button
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Like"
         android:onClick="onLike"
-        android:layout_below="@id/petName"
-        android:id="@+id/likeButtton"
-        android:layout_toRightOf="@id/passBtn"
-        />
+        android:layout_below="@id/text_pet_name"
+        android:id="@+id/button_like"
+        android:layout_toRightOf="@id/button_pass"/>
 
 </RelativeLayout>

--- a/app/src/main/res/menu/menu_pet_browser.xml
+++ b/app/src/main/res/menu/menu_pet_browser.xml
@@ -1,0 +1,10 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context="com.codepath.apps.critterfinder.activities.PetBrowserActivity">
+    <item
+        android:id="@+id/action_settings"
+        android:orderInCategory="100"
+        android:title="@string/action_settings"
+        app:showAsAction="never" />
+</menu>

--- a/app/src/main/res/menu/menu_pet_browser.xml
+++ b/app/src/main/res/menu/menu_pet_browser.xml
@@ -2,9 +2,10 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:context="com.codepath.apps.critterfinder.activities.PetBrowserActivity">
+
     <item
-        android:id="@+id/action_settings"
-        android:orderInCategory="100"
-        android:title="@string/action_settings"
-        app:showAsAction="never" />
+        android:id="@+id/menu_item_search"
+        android:title="@string/actionbar_search_title"
+        android:icon="@android:drawable/ic_menu_search"
+        app:showAsAction="ifRoom"/>
 </menu>

--- a/app/src/main/res/values/gender_array.xml
+++ b/app/src/main/res/values/gender_array.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="gender_array">
+        <item>Male</item>
+        <item>Female</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,5 +7,7 @@
     <!-- Pet Details Strings -->
     <string name="pet_details_description">Example text description. This is a great pet to adopt. Adopt me!</string>
     <string name="title_activity_pet_details">PetDetailsActivity</string>
+    <string name="title_activity_pet_browser"></string>
+    <string name="action_settings">Settings</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,7 +7,6 @@
     <!-- Pet Details Strings -->
     <string name="pet_details_description">Example text description. This is a great pet to adopt. Adopt me!</string>
     <string name="title_activity_pet_details">PetDetailsActivity</string>
-    <string name="title_activity_pet_browser"></string>
     <string name="action_settings">Settings</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,4 +9,9 @@
     <string name="title_activity_pet_details">PetDetailsActivity</string>
     <string name="action_settings">Settings</string>
 
+    <!-- Pet Browser -->
+    <string name="actionbar_search_title">Search Filters</string>
+
+    <!-- Search Filter Dialog -->
+    <string name="filter_save">Save</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,9 @@ buildscript {
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.android.tools.build:gradle:1.5.0'
         classpath 'com.github.JakeWharton:sdk-manager-plugin:220bf7a88a7072df3ed16dc8466fb144f2817070'
+        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
     }
 }
 


### PR DESCRIPTION
@cbaja @scottrichards 

Will be easier to read this PR after https://github.com/TeamCritterFinder/CritterFinder/pull/15 is merged as this includes those changes.

1) Create a search filter dialog fragment to host the search filter UI
2) Create a model object representing a SearchFilter. Currently I just have gender and size. Will add more fields to the model later.
3) Add a search button to the pet browse activity toolbar
4) Tapping on the search button opens our search dialog fragment
5) Change the gender and hit the save button - the updated criteria is passed back to the browse activity.
6) As part of this work I added Parcelable to our gradle file so the SearchFilter model could be passed from the browse activity into the search dialog fragment.

<img width="528" alt="screen shot 2016-03-03 at 1 23 31 am" src="https://cloud.githubusercontent.com/assets/1521460/13489938/94dc44bc-e0de-11e5-9fb6-5d6a25a224f3.png">

<img width="538" alt="screen shot 2016-03-03 at 1 23 38 am" src="https://cloud.githubusercontent.com/assets/1521460/13489941/9da27760-e0de-11e5-9909-f19cf7b88c8f.png">
