### PR TITLE
Adding a material design color palette

### DIFF
--- a/app/src/main/res/layout/item_search_criteria.xml
+++ b/app/src/main/res/layout/item_search_criteria.xml
@@ -9,12 +9,14 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:textColor="@color/primary_text"
         android:textAppearance="?android:attr/textAppearanceLarge"
         android:id="@+id/text_title" />
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:textColor="@color/secondary_text"
         android:textAppearance="?android:attr/textAppearanceMedium"
         android:id="@+id/text_values"/>
 

--- a/app/src/main/res/menu/menu_pet_browser.xml
+++ b/app/src/main/res/menu/menu_pet_browser.xml
@@ -6,7 +6,6 @@
     <item
         android:id="@+id/menu_item_search"
         android:title="@string/actionbar_search_title"
-        android:tint="@color/primary_dark"
         android:icon="@android:drawable/ic_menu_search"
         app:showAsAction="ifRoom"/>
 </menu>

--- a/app/src/main/res/menu/menu_pet_browser.xml
+++ b/app/src/main/res/menu/menu_pet_browser.xml
@@ -6,6 +6,7 @@
     <item
         android:id="@+id/menu_item_search"
         android:title="@string/actionbar_search_title"
+        android:tint="@color/primary_dark"
         android:icon="@android:drawable/ic_menu_search"
         app:showAsAction="ifRoom"/>
 </menu>

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -6,4 +6,5 @@
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
+
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+
+    <color name="primary">#CDDC39</color>
+    <color name="primary_dark">#AFB42B</color>
+    <color name="primary_light">#F0F4C3</color>
+    <color name="accent">#FFC107</color>
+    <color name="primary_text">#212121</color>
+    <color name="secondary_text">#727272</color>
+    <color name="icons">#212121</color>
+    <color name="divider">#B6B6B6</color>
+
     <item name="blue" type="color">#FF33B5E5</item>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -10,7 +10,12 @@
 
     <!-- Application theme. -->
     <style name="AppTheme" parent="AppBaseTheme">
-        <!-- All customizations that are NOT specific to a particular API-level can go here. -->
+        <!-- Application theme. -->
+        <item name="colorPrimary">@color/primary</item>
+        <item name="colorPrimaryDark">@color/primary_dark</item>
+        <item name="colorAccent">@color/accent</item>
+        <item name="android:textColorPrimary">@color/primary_text</item>
+        <item name="android:textColor">@color/secondary_text</item>
     </style>
 
     <style name="AppTheme.NoActionBar">


### PR DESCRIPTION
@cbaja @scottrichards 

I needed a break from coding so I grabbed a material design color palette from: http://www.materialpalette.com/lime/amber. 

We can change the theme easily later to pick colors we all like. All we'll have to do is update colors.xml to change it.

It exports XML that looks like:

```
    <color name="primary">#CDDC39</color>
    <color name="primary_dark">#AFB42B</color>
    <color name="primary_light">#F0F4C3</color>
    <color name="accent">#FFC107</color>
    <color name="primary_text">#212121</color>
    <color name="secondary_text">#727272</color>
    <color name="icons">#212121</color>
    <color name="divider">#B6B6B6</color>
```

which goes directly into our colors.xml file.

I then started using the colors in the search filter UI:

i.e.

```
    <TextView
        android:layout_width="wrap_content"
        android:layout_height="wrap_content"
        *android:textColor="@color/primary_text"*
        android:textAppearance="?android:attr/textAppearanceLarge"
        android:id="@+id/text_title" />
```

Was hoping text views would just inherit the correct text color for the theme but didn't want to spend more time at the moment on that.
