### PR TITLE
Add a simple favorites service. Power the favorites list by pets the user has expressed interest in

### DIFF
--- a/app/src/main/java/com/codepath/apps/critterfinder/fragments/PetFavoritesFragment.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/fragments/PetFavoritesFragment.java
@@ -13,10 +13,10 @@ import com.codepath.apps.critterfinder.R;
 import com.codepath.apps.critterfinder.activities.PetDetailsActivity;
 import com.codepath.apps.critterfinder.adapters.PetFavoritesAdapter;
 import com.codepath.apps.critterfinder.models.PetModel;
-import com.codepath.apps.critterfinder.services.PetSearch;
+import com.codepath.apps.critterfinder.services.FavoritesService;
 import com.codepath.apps.critterfinder.utils.DividerItemDecoration;
 
-import java.util.ArrayList;
+import java.util.List;
 
 import butterknife.Bind;
 import butterknife.ButterKnife;
@@ -50,7 +50,7 @@ public class PetFavoritesFragment extends Fragment {
 
     public void setupFavoritesPet(){
         // Create and Initialize pets
-        final ArrayList<PetModel> pets = PetSearch.getInstance().petsList;
+        final List<PetModel> pets = FavoritesService.getInstance().getFavoritePets();
 
         // Create adapter passing in the sample user data
         PetFavoritesAdapter adapter = new PetFavoritesAdapter(pets);

--- a/app/src/main/java/com/codepath/apps/critterfinder/fragments/SwipeablePetsFragment.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/fragments/SwipeablePetsFragment.java
@@ -1,7 +1,6 @@
 package com.codepath.apps.critterfinder.fragments;
 
 import android.os.Bundle;
-import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -15,6 +14,7 @@ import android.widget.TextView;
 import com.codepath.apps.critterfinder.R;
 import com.codepath.apps.critterfinder.models.PetModel;
 import com.codepath.apps.critterfinder.models.SearchFilter;
+import com.codepath.apps.critterfinder.services.FavoritesService;
 import com.codepath.apps.critterfinder.services.PetSearch;
 import com.squareup.picasso.Picasso;
 
@@ -34,6 +34,7 @@ public class SwipeablePetsFragment extends Fragment implements PetSearch.PetSear
     private PetSearch petSearch;
     private LinearLayout loadingProgress;
     private SearchFilter mSearchFilter;
+    private PetModel mCurrentPet;
 
     @Bind(R.id.text_pet_gender) TextView mPetGender;
     @Bind(R.id.text_pet_name) TextView mPetName;
@@ -71,13 +72,13 @@ public class SwipeablePetsFragment extends Fragment implements PetSearch.PetSear
 
     @OnClick(R.id.button_like)
     public void onLikeButtonClicked(Button button) {
-        Snackbar.make(getActivity().findViewById(android.R.id.content), "Yeah you like this pet!", Snackbar.LENGTH_LONG).show();
+        FavoritesService.getInstance().addFavoritePet(mCurrentPet);
         updateViewWithPet(petSearch.getNextPet(this));
     }
 
     @OnClick(R.id.button_pass)
     public void onPassButtonClicked(Button button) {
-        Snackbar.make(getActivity().findViewById(android.R.id.content), "Keep trying the right pet is out there!", Snackbar.LENGTH_LONG).show();
+        FavoritesService.getInstance().skipPet(mCurrentPet);
         updateViewWithPet(petSearch.getNextPet(this));
     }
 
@@ -85,6 +86,7 @@ public class SwipeablePetsFragment extends Fragment implements PetSearch.PetSear
     private void updateViewWithPet(PetModel petModel) {
         this.mPetName.setText(petModel.getName());
         this.mPetGender.setText(petModel.getSex());
+        mCurrentPet = petModel;
         Picasso.with(mPetImage.getContext()).load(petModel.getImageUrl()).into(mPetImage);
     }
 

--- a/app/src/main/java/com/codepath/apps/critterfinder/models/PetModel.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/models/PetModel.java
@@ -18,6 +18,7 @@ public class PetModel {
     String age;
     String size;
     String description;
+    long serverId;
 
     private static String weirdNameSpace = "$t";
 
@@ -39,7 +40,11 @@ public class PetModel {
         return description;
     }
 
-   public PetModel(String name, String sex, String image){
+    public long getServerId() {
+        return serverId;
+    }
+
+    public PetModel(String name, String sex, String image){
        this.name = name;
        this.sex = sex;
        this.imageUrl = image;
@@ -49,6 +54,7 @@ public class PetModel {
         try {
             this.name = petJson.getJSONObject("name").getString(weirdNameSpace);
             this.sex = petJson.getJSONObject("sex").getString(weirdNameSpace);
+            this.serverId = petJson.getJSONObject("id").getLong(weirdNameSpace);
             this.description = petJson.getJSONObject("description").getString(weirdNameSpace);
             JSONObject photosObject = petJson.getJSONObject("media").getJSONObject("photos");
             if (photosObject != null) {

--- a/app/src/main/java/com/codepath/apps/critterfinder/services/FavoritesService.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/services/FavoritesService.java
@@ -1,0 +1,67 @@
+package com.codepath.apps.critterfinder.services;
+
+import com.codepath.apps.critterfinder.models.PetModel;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Created by smacgregor on 3/7/16.
+ */
+public class FavoritesService {
+
+    private static FavoritesService mInstance = new FavoritesService();
+    private List<PetModel> mFavorites;
+    private Set<Long> mSkippedSet;
+
+    public static FavoritesService getInstance() {
+        return mInstance;
+    }
+
+    private FavoritesService() {
+        mFavorites = new ArrayList<>();
+        mSkippedSet = new HashSet<>();
+    }
+
+    /**
+     * Mark a pet as a favorite
+     * @param pet
+     */
+    public void addFavoritePet(PetModel pet) {
+        mFavorites.add(pet);
+    }
+
+    /**
+     * The list of pets the user has marked as favorites
+     * @return
+     */
+    public List<PetModel> getFavoritePets() {
+        return mFavorites;
+    }
+
+    /**
+     * When a user is not interested in a particular pet
+     * @param pet
+     */
+    public void skipPet(PetModel pet) {
+        mSkippedSet.add(pet.getServerId());
+    }
+
+    /**
+     * Remove all pets the user has previously decided they weren't interested in
+     * from the passed in list of pets.
+     * @param pets
+     * @return
+     */
+    public List<PetModel> removeSkippedPets(List<PetModel> pets) {
+        List<PetModel> filterdPetList = new ArrayList<>(pets.size());
+        for (PetModel pet : pets) {
+            if (!mSkippedSet.contains(pet.getServerId())) {
+                filterdPetList.add(pet);
+            }
+        }
+        return filterdPetList;
+    }
+}

--- a/app/src/main/res/layout/pet_favorites_items.xml
+++ b/app/src/main/res/layout/pet_favorites_items.xml
@@ -3,7 +3,7 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:padding="8dp"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content">
 
     <ImageView
         android:layout_alignParentTop="true"


### PR DESCRIPTION
@cbaja @scottrichards 

Issue #46 - keep track of skipped pets and remove skipped pets from a passed in list of pets
Issue #52 - when scrolling the favorites list view each row item suddenly takes a bunch of white space

A simple in memory service that keeps track of favorite and skipped pets. I updated the favorites fragment to be powered based on favorite pets. 

![favorites](https://cloud.githubusercontent.com/assets/1521460/13594344/83962f82-e4b8-11e5-974a-f70f4f4c12fc.gif)
