### PR TITLE
Improve the transition between favorites and details

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     compile 'com.android.support:recyclerview-v7:23.1.1'
     apt 'org.parceler:parceler:1.0.4'
     compile 'org.parceler:parceler-api:1.0.4'
-    compile 'com.makeramen:roundedimageview:2.2.1'
+    compile 'de.hdodenhof:circleimageview:2.0.0'
 
     // Material design dialogs
     compile('com.github.afollestad.material-dialogs:core:0.8.5.6@aar') {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,6 +43,7 @@
         </activity>
         <activity
             android:name=".activities.PetDetailsActivity"
+            android:label=""
             android:theme="@style/AppTheme.NoActionBar">
         </activity>
         <activity

--- a/app/src/main/java/com/codepath/apps/critterfinder/activities/PetBrowserActivity.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/activities/PetBrowserActivity.java
@@ -38,7 +38,7 @@ public class PetBrowserActivity extends AppCompatActivity implements
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
-
+        
         mSearchFilter = new SearchFilter();
 
         if (savedInstanceState == null) {

--- a/app/src/main/java/com/codepath/apps/critterfinder/activities/PetDetailsActivity.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/activities/PetDetailsActivity.java
@@ -60,9 +60,7 @@ public class PetDetailsActivity extends AppCompatActivity {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
-            // for now the back button will save the results
-            finish();
-            overridePendingTransition(R.anim.left_in, R.anim.right_out);
+            supportFinishAfterTransition();
             return true;
         } else {
             return super.onOptionsItemSelected(item);

--- a/app/src/main/java/com/codepath/apps/critterfinder/adapters/PetFavoritesAdapter.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/adapters/PetFavoritesAdapter.java
@@ -14,6 +14,8 @@ import com.squareup.picasso.Picasso;
 
 import java.util.List;
 
+import de.hdodenhof.circleimageview.CircleImageView;
+
 /**
  * Created by carlybaja on 3/2/16.
  */
@@ -34,7 +36,7 @@ public class PetFavoritesAdapter extends RecyclerView.Adapter<PetFavoritesAdapte
         // for any view that will be set as you render a row
         public TextView tvPetFavName;
         public TextView tvPetFavSex;
-        public ImageView ivPetFavImage;
+        public CircleImageView ivPetFavImage;
 
         // We also create a constructor that accepts the entire item row
         // and does the view lookups to find each subview
@@ -45,14 +47,14 @@ public class PetFavoritesAdapter extends RecyclerView.Adapter<PetFavoritesAdapte
 
             tvPetFavName = (TextView) itemView.findViewById(R.id.petFavName);
             tvPetFavSex = (TextView) itemView.findViewById(R.id.petFavSex);
-            ivPetFavImage = (ImageView) itemView.findViewById(R.id.petFavImage);
+            ivPetFavImage = (CircleImageView) itemView.findViewById(R.id.petFavImage);
             itemView.setOnClickListener(this);
         }
 
         @Override
         public void onClick(View v) {
             if (mOnItemClickListener != null) {
-                mOnItemClickListener.onItemClick(v, getAdapterPosition());
+                mOnItemClickListener.onItemClick(v, ivPetFavImage, getAdapterPosition());
             }
         }
     }
@@ -102,7 +104,7 @@ public class PetFavoritesAdapter extends RecyclerView.Adapter<PetFavoritesAdapte
          * @param view
          * @param position
          */
-        void onItemClick(View view, int position);
+        void onItemClick(View view, View transitionSourceView, int position);
     }
 
     /**

--- a/app/src/main/java/com/codepath/apps/critterfinder/fragments/PetDetailsFragment.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/fragments/PetDetailsFragment.java
@@ -59,6 +59,7 @@ public class PetDetailsFragment extends Fragment {
         mPetGender.setText(mPet.getSexFullName());
         Picasso.with(mPetImage.getContext()).
                 load(mPet.getImageUrl()).
+                //resize(DeviceDimensionsHelper.getDisplayWidth(getContext()), 0).
                 into(mPetImage);
         mPetDescription.setText(mPet.getDescription());
     }

--- a/app/src/main/java/com/codepath/apps/critterfinder/fragments/PetDetailsFragment.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/fragments/PetDetailsFragment.java
@@ -54,7 +54,6 @@ public class PetDetailsFragment extends Fragment {
     }
 
     private void setupPetDetailsView() {
-        getActivity().setTitle(mPet.getName());
         mPetName.setText(mPet.getName());
         mPetGender.setText(mPet.getSexFullName());
         Picasso.with(mPetImage.getContext()).

--- a/app/src/main/java/com/codepath/apps/critterfinder/fragments/PetFavoritesFragment.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/fragments/PetFavoritesFragment.java
@@ -2,6 +2,7 @@ package com.codepath.apps.critterfinder.fragments;
 
 
 import android.os.Bundle;
+import android.support.v4.app.ActivityOptionsCompat;
 import android.support.v4.app.Fragment;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -54,9 +55,9 @@ public class PetFavoritesFragment extends Fragment {
 
         adapter.setOnItemClickListener(new PetFavoritesAdapter.OnItemClickListener() {
             @Override
-            public void onItemClick(View view, int position) {
-                startActivity(PetDetailsActivity.getStartIntent(getContext(),pets.get(position)));
-                getActivity().overridePendingTransition(R.anim.right_in, R.anim.left_out);
+            public void onItemClick(View view, View transitionSourceView,  int position) {
+                ActivityOptionsCompat options = ActivityOptionsCompat.makeSceneTransitionAnimation(getActivity(), transitionSourceView, "details");
+                startActivity(PetDetailsActivity.getStartIntent(getContext(), pets.get(position)), options.toBundle());
             }
         });
         // Attach the adapter to the recyclerview to populate items

--- a/app/src/main/java/com/codepath/apps/critterfinder/utils/DeviceDimensionsHelper.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/utils/DeviceDimensionsHelper.java
@@ -1,0 +1,39 @@
+package com.codepath.apps.critterfinder.utils;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.util.DisplayMetrics;
+import android.util.TypedValue;
+
+/**
+ * Created by nesquena on 2/4/16.
+ * https://gist.github.com/nesquena/318b6930aac3a56f96a4
+ */
+
+public class DeviceDimensionsHelper {
+    // DeviceDimensionsHelper.getDisplayWidth(context) => (display width in pixels)
+    public static int getDisplayWidth(Context context) {
+        DisplayMetrics displayMetrics = context.getResources().getDisplayMetrics();
+        return displayMetrics.widthPixels;
+    }
+
+    // DeviceDimensionsHelper.getDisplayHeight(context) => (display height in pixels)
+    public static int getDisplayHeight(Context context) {
+        DisplayMetrics displayMetrics = context.getResources().getDisplayMetrics();
+        return displayMetrics.heightPixels;
+    }
+
+    // DeviceDimensionsHelper.convertDpToPixel(25f, context) => (25dp converted to pixels)
+    public static float convertDpToPixel(float dp, Context context){
+        Resources r = context.getResources();
+        return TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dp, r.getDisplayMetrics());
+    }
+
+    // DeviceDimensionsHelper.convertPixelsToDp(25f, context) => (25px converted to dp)
+    public static float convertPixelsToDp(float px, Context context){
+        Resources r = context.getResources();
+        DisplayMetrics metrics = r.getDisplayMetrics();
+        float dp = px / (metrics.densityDpi / 160f);
+        return dp;
+    }
+}

--- a/app/src/main/res/drawable/actionbar_gradient_dark.xml
+++ b/app/src/main/res/drawable/actionbar_gradient_dark.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <gradient
+        android:angle="90"
+        android:centerColor="#00ffffff"
+        android:startColor="#00ffffff"
+        android:endColor="#aa000000"/>
+    <corners android:radius="0dp"/>
+
+</shape>

--- a/app/src/main/res/layout/activity_pet_details.xml
+++ b/app/src/main/res/layout/activity_pet_details.xml
@@ -16,7 +16,7 @@
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
-            android:background="?attr/colorPrimary"
+            android:background="@android:color/transparent"
             app:popupTheme="@style/AppTheme.PopupOverlay" />
 
     </android.support.design.widget.AppBarLayout>

--- a/app/src/main/res/layout/activity_pet_details.xml
+++ b/app/src/main/res/layout/activity_pet_details.xml
@@ -7,21 +7,21 @@
     android:fitsSystemWindows="true"
     tools:context="com.codepath.apps.critterfinder.activities.PetDetailsActivity">
 
-    <android.support.design.widget.AppBarLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:theme="@style/AppTheme.AppBarOverlay">
+
+    <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_height="match_parent"
+        android:layout_width="match_parent">
+
+        <include layout="@layout/content_pet_details" />
 
         <android.support.v7.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
-            android:background="@android:color/transparent"
+            app:theme="@style/TransparentToolbar"
             app:popupTheme="@style/AppTheme.PopupOverlay" />
 
-    </android.support.design.widget.AppBarLayout>
-
-    <include layout="@layout/content_pet_details" />
+    </FrameLayout>
 
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/pet_details_fab"

--- a/app/src/main/res/layout/content_pet_details.xml
+++ b/app/src/main/res/layout/content_pet_details.xml
@@ -4,10 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
     app:layout_behavior="@string/appbar_scrolling_view_behavior"
     tools:context="com.codepath.apps.critterfinder.activities.PetDetailsActivity"
     tools:showIn="@layout/activity_pet_details">

--- a/app/src/main/res/layout/fragment_pet_details.xml
+++ b/app/src/main/res/layout/fragment_pet_details.xml
@@ -6,15 +6,26 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <ImageView
+    <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="300dp"
-        android:scaleType="centerCrop"
-        android:transitionName="details"
-        android:layout_alignParentTop="true"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:id="@+id/image_pet"/>
+        android:layout_height="wrap_content">
+            <ImageView
+                android:layout_width="match_parent"
+                android:layout_height="300dp"
+                android:scaleType="centerCrop"
+                android:transitionName="details"
+                android:layout_alignParentTop="true"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:id="@+id/image_pet"/>
+        
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="300dp"
+            android:background="@drawable/actionbar_gradient_dark"/>
+        
+    </FrameLayout>
+
 
     <RelativeLayout
         android:paddingBottom="@dimen/activity_vertical_margin"

--- a/app/src/main/res/layout/fragment_pet_details.xml
+++ b/app/src/main/res/layout/fragment_pet_details.xml
@@ -9,31 +9,40 @@
     <ImageView
         android:layout_width="match_parent"
         android:layout_height="300dp"
-        android:scaleType="fitCenter"
+        android:scaleType="centerCrop"
+        android:transitionName="details"
         android:layout_alignParentTop="true"
         android:layout_alignParentLeft="true"
         android:layout_alignParentStart="true"
         android:id="@+id/image_pet"/>
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true"
-        android:layout_below="@id/image_pet"
-        android:text="Pet Name"
-        android:id="@+id/text_pet_name"/>
+    <RelativeLayout
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+        android:orientation="vertical">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:text="Pet Name"
+                android:id="@+id/text_pet_name"/>
 
-    <TextView
-        android:layout_below="@id/text_pet_name"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true"
-        android:id="@+id/text_pet_gender"/>
+            <TextView
+                android:layout_below="@id/text_pet_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:id="@+id/text_pet_gender"/>
 
-    <TextView
-        android:id="@+id/text_pet_description"
-        android:layout_below="@id/text_pet_name"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+            <TextView
+                android:id="@+id/text_pet_description"
+                android:layout_below="@id/text_pet_gender"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+    </RelativeLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/pet_favorites_items.xml
+++ b/app/src/main/res/layout/pet_favorites_items.xml
@@ -5,13 +5,15 @@
     android:padding="8dp"
     android:layout_height="wrap_content">
 
-    <ImageView
+    <de.hdodenhof.circleimageview.CircleImageView
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:transitionName="details"
         android:layout_alignParentTop="true"
         android:layout_alignParentStart="true"
         android:layout_alignParentLeft="true"
-        android:scaleType="fitCenter"
-        android:layout_width="75dp"
-        android:layout_height="75dp"
+        android:scaleType="centerCrop"
+        android:layout_width="96dp"
+        android:layout_height="96dp"
         android:id="@+id/petFavImage"/>
 
     <TextView

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -5,6 +5,7 @@
         <item name="windowNoTitle">true</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowContentTransitions">true</item>
     </style>
 
 </resources>

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -5,7 +5,11 @@
         <item name="windowNoTitle">true</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
-        <item name="android:windowContentTransitions">true</item>
+    </style>
+
+    <style name="TransparentToolbar" parent="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+        <item name="android:windowActionBarOverlay">true</item>
+        <item name="windowActionBarOverlay">true</item>
     </style>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -23,7 +23,8 @@
         <item name="windowNoTitle">true</item>
     </style>
 
-    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
+    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar">
+    </style>
 
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 


### PR DESCRIPTION
Issue #42  - prep work for transitioning from the browser view to the details view. I first started with the transition from favorites to details as that one was easier.

Check out this guide for activity to activity transitions or fragment transitions. It was super useful for getting this part to work: 

https://github.com/codepath/android_guides/wiki/Shared-Element-Activity-Transition

The secret sauce happens by tagging an element from the one view that's going to be in the other view. In this case the picture of the pet in the favorite's activity is going to be in the details view as well.

Enter makeSceneTransitionAnimation!

ActivityOptionsCompat options = ActivityOptionsCompat.makeSceneTransitionAnimation(getActivity(), transitionSourceView, "details");

![transition](https://cloud.githubusercontent.com/assets/1521460/13722165/11e60e1c-e7f0-11e5-8960-c83602dbd2a8.gif)

I also made the toolbar on the pet details screen transparent and put the image of the pet underneath the action bar.

fun stuff.
