### PR TITLE
Issue #50 - Tapping on a card from the swipe view should transition to the details card.

### DIFF
--- a/app/src/main/java/com/codepath/apps/critterfinder/activities/PetBrowserActivity.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/activities/PetBrowserActivity.java
@@ -4,13 +4,16 @@ import android.Manifest;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.design.widget.Snackbar;
+import android.support.v4.app.ActivityOptionsCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
 
 import com.codepath.apps.critterfinder.R;
 import com.codepath.apps.critterfinder.fragments.SwipeablePetsFragment;
+import com.codepath.apps.critterfinder.models.PetModel;
 import com.codepath.apps.critterfinder.models.SearchFilter;
 import com.codepath.apps.critterfinder.services.LocationService;
 
@@ -22,7 +25,8 @@ import permissions.dispatcher.RuntimePermissions;
 
 @RuntimePermissions
 public class PetBrowserActivity extends AppCompatActivity implements
-        LocationService.OnLocationListener {
+        LocationService.OnLocationListener,
+        SwipeablePetsFragment.OnSwipeablePetsFragmentListener {
 
     private final int SEARCH_FILTER_REQUEST_CODE = 20;
 
@@ -105,6 +109,14 @@ public class PetBrowserActivity extends AppCompatActivity implements
             mSearchFilter = Parcels.unwrap(data.getParcelableExtra(PetSearchFilterActivity.EXTRA_SEARCH_FILTER));
             mSwipeablePetsFragment.doPetSearch(mSearchFilter);
         }
+    }
+
+    @Override
+    public void onPetSelected(PetModel pet, View transitionView) {
+        ActivityOptionsCompat options = ActivityOptionsCompat.makeSceneTransitionAnimation(this, transitionView, "details");
+        Intent intent = PetDetailsActivity.getStartIntent(this, pet);
+        intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        startActivity(intent, options.toBundle());
     }
 
     private void showSearchFilterDialog() {

--- a/app/src/main/java/com/codepath/apps/critterfinder/fragments/SwipeablePetsFragment.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/fragments/SwipeablePetsFragment.java
@@ -1,5 +1,6 @@
 package com.codepath.apps.critterfinder.fragments;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.util.Log;
@@ -30,13 +31,15 @@ import butterknife.OnClick;
  * Our tinder-like pet browser
  */
 public class SwipeablePetsFragment extends Fragment implements PetSearch.PetSearchCallbackInterface,
-        SwipeFlingAdapterView.onFlingListener {
+        SwipeFlingAdapterView.onFlingListener,
+        SwipeFlingAdapterView.OnItemClickListener {
 
     private static final String ARGUMENT_SEARCH_FILTER = "ARGUMENT_SEARCH_FILTER";
 
     private PetSearch petSearch;
     private LinearLayout loadingProgress;
     private SearchFilter mSearchFilter;
+    private OnSwipeablePetsFragmentListener mFragmentListener;
 
     @Bind(R.id.card_view) SwipeFlingAdapterView mCardContainer;
 
@@ -66,6 +69,16 @@ public class SwipeablePetsFragment extends Fragment implements PetSearch.PetSear
     }
 
     @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        if (context instanceof OnSwipeablePetsFragmentListener) {
+            mFragmentListener = (OnSwipeablePetsFragmentListener)context;
+        } else {
+            throw new RuntimeException(context.toString());
+        }
+    }
+
+    @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         View currentView = inflater.inflate(R.layout.fragment_swipeable_pets, container, false);
@@ -74,6 +87,7 @@ public class SwipeablePetsFragment extends Fragment implements PetSearch.PetSear
 
         mCardContainer.setAdapter(mCardAdapter);
         mCardContainer.setFlingListener(this);
+        mCardContainer.setOnItemClickListener(this);
         doPetSearch(mSearchFilter);
         return currentView;
     }
@@ -107,6 +121,12 @@ public class SwipeablePetsFragment extends Fragment implements PetSearch.PetSear
         View view = mCardContainer.getSelectedView();
         view.findViewById(R.id.item_swipe_right_indicator).setAlpha(scrollProgressPercent < 0 ? -scrollProgressPercent : 0);
         view.findViewById(R.id.item_swipe_left_indicator).setAlpha(scrollProgressPercent > 0 ? scrollProgressPercent : 0);
+    }
+
+    @Override
+    public void onItemClicked(int i, Object o) {
+        View view = mCardContainer.getSelectedView();
+        mFragmentListener.onPetSelected((PetModel) o, view.findViewById(R.id.image_pet));
     }
 
     @OnClick(R.id.button_like)
@@ -145,5 +165,9 @@ public class SwipeablePetsFragment extends Fragment implements PetSearch.PetSear
     public void onPetSearchError(String result) {
  //       loadingProgress.setVisibility(View.GONE);
         Log.d("FindActivity", "ERROR");
+    }
+
+    public interface OnSwipeablePetsFragmentListener {
+        void onPetSelected(PetModel pet, View transitionView);
     }
 }

--- a/app/src/main/res/layout/item_swipeable_card.xml
+++ b/app/src/main/res/layout/item_swipeable_card.xml
@@ -13,6 +13,7 @@
         <ImageView
             android:layout_width="match_parent"
             android:layout_height="450dp"
+            android:transitionName="details"
             android:scaleType="centerCrop"
             android:id="@+id/image_pet"/>
 


### PR DESCRIPTION
Issue #50  - Tapping on a card from the browse activity transitions to the details activity for the selected pet. 

I used a shared element activity transition to make this work. Like PR #65 I leveraged https://github.com/codepath/android_guides/wiki/Shared-Element-Activity-Transition
if you'd like to learn more about how that works.

TODO - I'm working on having the back arrow point down instead of left.

![details](https://cloud.githubusercontent.com/assets/1521460/13725016/593fb1ae-e84b-11e5-8640-44fc25b43324.gif)
