### PR TITLE
Add a collapsing toolbar effect to the details view. Make the entire details activity scroll.

### DIFF
--- a/app/src/main/java/com/codepath/apps/critterfinder/activities/PetDetailsActivity.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/activities/PetDetailsActivity.java
@@ -4,16 +4,20 @@ import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.design.widget.CollapsingToolbarLayout;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
+import android.support.v4.view.ViewPager;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.MenuItem;
 import android.view.View;
 
 import com.codepath.apps.critterfinder.R;
+import com.codepath.apps.critterfinder.adapters.ImageGalleryAdapter;
 import com.codepath.apps.critterfinder.fragments.PetDetailsFragment;
 import com.codepath.apps.critterfinder.models.PetModel;
+import com.viewpagerindicator.CirclePageIndicator;
 
 import org.parceler.Parcels;
 
@@ -25,6 +29,9 @@ public class PetDetailsActivity extends AppCompatActivity implements FloatingAct
     private static String EXTRA_PET = "com.codepath.apps.critterfinder.activities.details.pet";
     private PetModel mPet;
     @Bind(R.id.pet_details_fab) FloatingActionButton mFloatingActionButton;
+    @Bind(R.id.pet_image_gallery) ViewPager mImageGallery;
+    @Bind(R.id.image_gallery_page_indicator) CirclePageIndicator mPageIndicator;
+    private ImageGalleryAdapter mImageGalleryAdapter;
 
     /**
      * Create an intent which will start the pet details activity
@@ -57,6 +64,11 @@ public class PetDetailsActivity extends AppCompatActivity implements FloatingAct
         if (savedInstanceState == null) {
             setupPetDetails(mPet);
         }
+
+        CollapsingToolbarLayout collapsingToolbarLayout = (CollapsingToolbarLayout) findViewById(R.id.details_collapsing_toolbar);
+        collapsingToolbarLayout.setTitle(mPet.getName());
+
+        setupPetImageGallery();
     }
 
     @Override
@@ -104,5 +116,12 @@ public class PetDetailsActivity extends AppCompatActivity implements FloatingAct
             Snackbar.make(findViewById(android.R.id.content), getString(R.string.contact_no_email_client), Snackbar.LENGTH_LONG).show();
 
         }
+    }
+
+    private void setupPetImageGallery() {
+        mImageGalleryAdapter = new ImageGalleryAdapter(this, mPet.getDetailImageUrls());
+        mImageGallery.setAdapter(mImageGalleryAdapter);
+        mPageIndicator.setSnap(true);
+        mPageIndicator.setViewPager(mImageGallery);
     }
 }

--- a/app/src/main/java/com/codepath/apps/critterfinder/fragments/PetDetailsFragment.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/fragments/PetDetailsFragment.java
@@ -2,22 +2,15 @@ package com.codepath.apps.critterfinder.fragments;
 
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
-import android.support.v4.view.ViewPager;
-import android.text.method.ScrollingMovementMethod;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
 import com.codepath.apps.critterfinder.R;
-import com.codepath.apps.critterfinder.adapters.ImageGalleryAdapter;
 import com.codepath.apps.critterfinder.models.PetModel;
-import com.viewpagerindicator.CirclePageIndicator;
 
 import org.parceler.Parcels;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import butterknife.Bind;
 import butterknife.ButterKnife;
@@ -38,9 +31,6 @@ public class PetDetailsFragment extends Fragment {
     @Bind(R.id.text_shelter_state) TextView mShelterContactState;
     @Bind(R.id.text_shelter_city) TextView mShelterCity;
     @Bind(R.id.text_shelter_email) TextView mShelterEmail;
-    @Bind(R.id.pet_image_gallery) ViewPager mImageGallery;
-    @Bind(R.id.image_gallery_page_indicator) CirclePageIndicator mPageIndicator;
-    private ImageGalleryAdapter mImageGalleryAdapter;
 
     private PetModel mPet;
 
@@ -63,7 +53,6 @@ public class PetDetailsFragment extends Fragment {
         View view = inflater.inflate(R.layout.fragment_pet_details, container, false);
         ButterKnife.bind(this, view);
         setupPetDetailsView();
-        setupPetImageGallery();
         return view;
     }
 
@@ -72,18 +61,10 @@ public class PetDetailsFragment extends Fragment {
         mPetGender.setText(mPet.getSexFullName());
         mPetBreed.setText(mPet.getBreedFullName());
         mPetDescription.setText(mPet.getDescription());
-        mPetDescription.setMovementMethod(new ScrollingMovementMethod());
         mShelterContactName.setText(mPet.getContactName());
         mShelterContactPhone.setText(mPet.getContactPhone());
         mShelterContactState.setText(mPet.getContactState());
         mShelterCity.setText(mPet.getContactCity()+", ");
         mShelterEmail.setText(mPet.getContactEmail());
-    }
-
-    private void setupPetImageGallery() {
-        mImageGalleryAdapter = new ImageGalleryAdapter(getContext(), mPet.getDetailImageUrls());
-        mImageGallery.setAdapter(mImageGalleryAdapter);
-        mPageIndicator.setSnap(true);
-        mPageIndicator.setViewPager(mImageGallery);
     }
 }

--- a/app/src/main/res/layout/activity_pet_details.xml
+++ b/app/src/main/res/layout/activity_pet_details.xml
@@ -23,7 +23,7 @@
             app:layout_scrollFlags="scroll|exitUntilCollapsed"
             android:fitsSystemWindows="true"
             app:contentScrim="?attr/colorPrimary"
-            app:expandedTitleMarginBottom="10dip"
+            app:expandedTitleMarginBottom="@dimen/pet_detail_title_bottom_padding"
             app:expandedTitleMarginStart="48dp"
             app:expandedTitleMarginEnd="64dp">
 

--- a/app/src/main/res/layout/activity_pet_details.xml
+++ b/app/src/main/res/layout/activity_pet_details.xml
@@ -1,27 +1,93 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
-    tools:context="com.codepath.apps.critterfinder.activities.PetDetailsActivity">
+    tools:context="com.codepath.apps.critterfinder.activities.PetDetailsActivity"
+    android:theme="@style/AppTheme">
 
+    <android.support.design.widget.AppBarLayout
+        android:id="@+id/appbar_layout"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/pet_details_image_height"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+        android:fitsSystemWindows="true">
 
-    <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        android:layout_height="match_parent"
-        android:layout_width="match_parent">
-
-        <include layout="@layout/content_pet_details" />
-
-        <android.support.v7.widget.Toolbar
-            android:id="@+id/toolbar"
+        <android.support.design.widget.CollapsingToolbarLayout
+            android:id="@+id/details_collapsing_toolbar"
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            app:theme="@style/TransparentToolbar"
-            app:popupTheme="@style/AppTheme.PopupOverlay" />
+            android:layout_height="@dimen/pet_details_image_height"
+            app:layout_scrollFlags="scroll|exitUntilCollapsed"
+            android:fitsSystemWindows="true"
+            app:contentScrim="?attr/colorPrimary"
+            app:expandedTitleMarginBottom="10dip"
+            app:expandedTitleMarginStart="48dp"
+            app:expandedTitleMarginEnd="64dp">
 
-    </FrameLayout>
+            <FrameLayout
+                android:fitsSystemWindows="true"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/pet_details_image_height">
+
+                <android.support.v4.view.ViewPager
+                    app:layout_scrollFlags="scroll|enterAlways|enterAlwaysCollapsed"
+                    android:transitionName="details"
+                    app:layout_collapseMode="parallax"
+                    android:fitsSystemWindows="true"
+                    android:id="@+id/pet_image_gallery"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/pet_details_image_height"/>
+
+                <com.viewpagerindicator.CirclePageIndicator
+                    android:fitsSystemWindows="true"
+                    android:id="@+id/image_gallery_page_indicator"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    style="@style/CustomCirclePageIndicator"
+                    app:layout_scrollFlags="scroll|enterAlways|enterAlwaysCollapsed"
+                    app:layout_collapseMode="parallax"
+                    android:background="@android:color/transparent"
+                    android:layout_gravity="bottom"/>
+
+                <View
+                    android:fitsSystemWindows="true"
+                    app:layout_scrollFlags="scroll|enterAlways|enterAlwaysCollapsed"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/pet_details_image_height"
+                    android:background="@drawable/actionbar_gradient_dark"/>
+            </FrameLayout>
+
+
+            <android.support.v7.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+                app:layout_scrollFlags="scroll|enterAlways"
+                app:layout_collapseMode="pin"/>
+
+        </android.support.design.widget.CollapsingToolbarLayout>
+    </android.support.design.widget.AppBarLayout>
+
+
+    <android.support.v4.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            android:layout_height="match_parent"
+            android:layout_width="match_parent">
+
+            <include layout="@layout/content_pet_details" />
+
+        </FrameLayout>
+
+    </android.support.v4.widget.NestedScrollView>
+
 
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/pet_details_fab"

--- a/app/src/main/res/layout/content_pet_details.xml
+++ b/app/src/main/res/layout/content_pet_details.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     app:layout_behavior="@string/appbar_scrolling_view_behavior"
     tools:context="com.codepath.apps.critterfinder.activities.PetDetailsActivity"
     tools:showIn="@layout/activity_pet_details">

--- a/app/src/main/res/layout/fragment_pet_details.xml
+++ b/app/src/main/res/layout/fragment_pet_details.xml
@@ -4,33 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-    <FrameLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <android.support.v4.view.ViewPager
-            android:transitionName="details"
-            android:id="@+id/pet_image_gallery"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/pet_details_image_height"/>
-        
-        <com.viewpagerindicator.CirclePageIndicator
-            android:id="@+id/image_gallery_page_indicator"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            style="@style/CustomCirclePageIndicator"
-            android:background="@android:color/transparent"
-            android:layout_gravity="bottom"/>
-        
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/pet_details_image_height"
-            android:background="@drawable/actionbar_gradient_dark"/>
-        
-    </FrameLayout>
-
+    android:layout_height="wrap_content">
 
     <RelativeLayout
         android:paddingBottom="@dimen/activity_vertical_margin"
@@ -63,11 +37,10 @@
                 android:id="@+id/text_pet_description"
                 android:layout_below="@id/text_pet_breed"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:scrollbars = "vertical"
-                android:maxLines="8"
-                android:ellipsize="end" />
+                android:layout_height="wrap_content"/>
+
     </RelativeLayout>
+
     <RelativeLayout
             android:paddingBottom="@dimen/activity_vertical_margin"
             android:paddingLeft="@dimen/activity_horizontal_margin"

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -7,9 +7,4 @@
         <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
 
-    <style name="TransparentToolbar" parent="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
-        <item name="android:windowActionBarOverlay">true</item>
-        <item name="windowActionBarOverlay">true</item>
-    </style>
-
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -9,6 +9,7 @@
     <color name="secondary_text">#727272</color>
     <color name="icons">#FFFFFF</color>
     <color name="divider">#B6B6B6</color>
+    <color name="window_background">#FFF5F5F5</color>
 
     <item name="blue" type="color">#FF33B5E5</item>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -6,5 +6,6 @@
     <dimen name="fab_margin">16dp</dimen>
     <dimen name="name_font_size">16sp</dimen>
     <dimen name="pet_details_image_height">340dp</dimen>
+    <dimen name="pet_detail_title_bottom_padding">10dip</dimen>
 
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -5,6 +5,6 @@
     <dimen name="activity_vertical_margin">16dp</dimen>
     <dimen name="fab_margin">16dp</dimen>
     <dimen name="name_font_size">16sp</dimen>
-    <dimen name="pet_details_image_height">300dp</dimen>
+    <dimen name="pet_details_image_height">340dp</dimen>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -16,6 +16,7 @@
         <item name="colorAccent">@color/accent</item>
         <item name="android:textColorPrimary">@color/primary_text</item>
         <item name="android:textColor">@color/secondary_text</item>
+        <item name="android:windowBackground">@color/window_background</item>
     </style>
 
     <style name="AppTheme.NoActionBar">


### PR DESCRIPTION
@cbaja  @scottrichards 

Issue #90  - Scroll the entire details page
Issue #91 - Collapse the details action bar on scroll

A picture says a thousand words:

![collapsing](https://cloud.githubusercontent.com/assets/1521460/13784095/2f5b3fb0-ea8b-11e5-9666-959b40a49fb7.gif)
## Implementation Notes
- I made heavy use of the Google Demo App here - https://github.com/chrisbanes/cheesesquare which demonstrates the same concept. Check out that project if you have time - it's pretty cool.
- I had to move the image gallery view pager out of the fragment and into the activity because the view pager goes inside the collapsing action bar and the action bar is part of the activity layout not the fragment. So now our pet details fragment is composed of just the text.
- Added a Nested ScrollingView around our pet details fragment to make it scroll.
- This code path guide was also useful: https://guides.codepath.com/android/Handling-Scrolls-with-CoordinatorLayout
## Question

Do we like having the Pet name on top of the photo. Note how it collapses into the toolbar as you scroll up. If we like it we can remove the pet name from the content below. If we don't like it we'll have an empty action bar when you scroll up and the action bar turns blue. Curious what you guys think.
