### PR TITLE
Browse View - Frame the card like a deck. Add more padding around the card.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     compile 'com.android.support:recyclerview-v7:23.1.1'
     apt 'org.parceler:parceler:1.0.4'
     compile 'org.parceler:parceler-api:1.0.4'
-    compile 'de.hdodenhof:circleimageview:2.0.0'
+    compile 'com.makeramen:roundedimageview:2.2.1'
 
     // Material design dialogs
     compile('com.github.afollestad.material-dialogs:core:0.8.5.6@aar') {

--- a/app/src/main/java/com/codepath/apps/critterfinder/adapters/PetFavoritesAdapter.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/adapters/PetFavoritesAdapter.java
@@ -10,11 +10,10 @@ import android.widget.TextView;
 
 import com.codepath.apps.critterfinder.R;
 import com.codepath.apps.critterfinder.models.PetModel;
+import com.makeramen.roundedimageview.RoundedImageView;
 import com.squareup.picasso.Picasso;
 
 import java.util.List;
-
-import de.hdodenhof.circleimageview.CircleImageView;
 
 /**
  * Created by carlybaja on 3/2/16.
@@ -36,7 +35,7 @@ public class PetFavoritesAdapter extends RecyclerView.Adapter<PetFavoritesAdapte
         // for any view that will be set as you render a row
         public TextView tvPetFavName;
         public TextView tvPetFavSex;
-        public CircleImageView ivPetFavImage;
+        public RoundedImageView ivPetFavImage;
         public TextView tvPetFavSize;
         public TextView tvPetFavAge;
         public TextView tvPetFavBreeds;
@@ -50,7 +49,7 @@ public class PetFavoritesAdapter extends RecyclerView.Adapter<PetFavoritesAdapte
 
             tvPetFavName = (TextView) itemView.findViewById(R.id.petFavName);
             tvPetFavSex = (TextView) itemView.findViewById(R.id.petFavSex);
-            ivPetFavImage = (CircleImageView) itemView.findViewById(R.id.petFavImage);
+            ivPetFavImage = (RoundedImageView) itemView.findViewById(R.id.petFavImage);
             tvPetFavSize = (TextView) itemView.findViewById(R.id.petFavSize);
             tvPetFavAge = (TextView) itemView.findViewById(R.id.petFavAge);
             tvPetFavBreeds = (TextView) itemView.findViewById(R.id.petFavBreeds);

--- a/app/src/main/java/com/codepath/apps/critterfinder/fragments/SwipeablePetsFragment.java
+++ b/app/src/main/java/com/codepath/apps/critterfinder/fragments/SwipeablePetsFragment.java
@@ -121,6 +121,7 @@ public class SwipeablePetsFragment extends Fragment implements PetSearch.PetSear
     @Override
     public void onScroll(float scrollProgressPercent) {
         View view = mCardContainer.getSelectedView();
+        view.findViewById(R.id.swipe_card_background).setAlpha(0); // hide the background frame on the card
         view.findViewById(R.id.item_swipe_right_indicator).setAlpha(scrollProgressPercent < 0 ? -scrollProgressPercent : 0);
         view.findViewById(R.id.item_swipe_left_indicator).setAlpha(scrollProgressPercent > 0 ? scrollProgressPercent : 0);
     }
@@ -128,18 +129,22 @@ public class SwipeablePetsFragment extends Fragment implements PetSearch.PetSear
     @Override
     public void onItemClicked(int i, Object o) {
         View view = mCardContainer.getSelectedView();
+        view.findViewById(R.id.swipe_card_background).setAlpha(0);
         mFragmentListener.onPetSelected((PetModel) o, view.findViewById(R.id.image_pet));
     }
 
     @OnClick(R.id.button_like)
     public void onLikeButtonClicked(Button button) {
+        // hide the frame on the card being dismissed
+        mCardContainer.getSelectedView().findViewById(R.id.swipe_card_background).setAlpha(0);
         // route the click through the card which understands which pet is currently selected
         mCardContainer.getTopCardListener().selectRight();
     }
 
     @OnClick(R.id.button_pass)
     public void onPassButtonClicked(Button button) {
-        // route the click through the card which understands which pet is currently selected
+        // hide the frame on the card being dismissed
+        mCardContainer.getSelectedView().findViewById(R.id.swipe_card_background).setAlpha(0);
         mCardContainer.getTopCardListener().selectLeft();
     }
 

--- a/app/src/main/res/drawable/shape.xml
+++ b/app/src/main/res/drawable/shape.xml
@@ -2,8 +2,8 @@
     <solid android:color="#F5F5F5"/>
     <corners android:radius="4dp"/>
     <padding
-        android:left="4dp"
-        android:top="4dp"
-        android:right="4dp"
-        android:bottom="4dp"/>
+        android:left="@dimen/activity_horizontal_margin"
+        android:top="@dimen/activity_vertical_margin"
+        android:right="@dimen/activity_horizontal_margin"
+        android:bottom="@dimen/activity_vertical_margin"/>
 </shape>

--- a/app/src/main/res/drawable/shape1.xml
+++ b/app/src/main/res/drawable/shape1.xml
@@ -1,12 +1,14 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <solid
-        android:color="#ccc"
+        android:color="#FDFDFD"
         />
     <corners
         android:radius="4dp" />
+    <stroke
+        android:width="2dp"
+        android:color="@color/swipe_card_border_color"/>
+
     <padding
         android:left="10dp"
-        android:top="10dp"
-        android:right="10dp"
-        android:bottom="10dp" />
+        android:right="10dp"/>
 </shape>

--- a/app/src/main/res/drawable/shape_2.xml
+++ b/app/src/main/res/drawable/shape_2.xml
@@ -1,9 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="#FFFFFF"/>
-    <corners android:radius="4dp"/>
+    <solid android:color="#FCFCFC"/>
+
+    <corners
+        android:radius="4dp" />
+
     <stroke
         android:width="2dp"
         android:color="@color/swipe_card_border_color"/>
+
     <padding
-        android:bottom="10dp" />
+        android:left="10dp"
+        android:right="10dp"/>
 </shape>

--- a/app/src/main/res/layout/content_pet_browser.xml
+++ b/app/src/main/res/layout/content_pet_browser.xml
@@ -5,7 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:background="@android:color/white"
     app:layout_behavior="@string/appbar_scrolling_view_behavior"
     tools:context="com.codepath.apps.simpletweets.activities.ProfileActivity"
     tools:showIn="@layout/activity_pet_browser">

--- a/app/src/main/res/layout/fragment_swipeable_pets.xml
+++ b/app/src/main/res/layout/fragment_swipeable_pets.xml
@@ -26,8 +26,11 @@
     <com.lorentzos.flingswipe.SwipeFlingAdapterView
         xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
-        android:layout_height="500dp"
+        android:layout_height="475dp"
         android:id="@+id/card_view"
+        android:layout_marginEnd="@dimen/activity_horizontal_margin"
+        android:layout_marginStart="@dimen/activity_horizontal_margin"
+        android:layout_marginTop="@dimen/activity_vertical_margin"
         app:rotation_degrees="16"
         app:max_visible="4"
         app:min_adapter_stack="6" />
@@ -60,3 +63,4 @@
     </LinearLayout>
 
 </RelativeLayout>
+

--- a/app/src/main/res/layout/item_swipeable_card.xml
+++ b/app/src/main/res/layout/item_swipeable_card.xml
@@ -7,7 +7,7 @@
     <FrameLayout
         android:id="@+id/swipe_card_background"
         android:layout_width="match_parent"
-        android:layout_height="470dp">
+        android:layout_height="@dimen/pet_swipecard_frame_height">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -35,7 +35,7 @@
         android:background="@drawable/shape"
         android:gravity="top|center_horizontal"
         android:layout_width="match_parent"
-        android:layout_height="450dp">
+        android:layout_height="@dimen/pet_swipecard_height">
 
         <com.makeramen.roundedimageview.RoundedImageView
             xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -45,7 +45,7 @@
             android:layout_marginRight="2dp"
             app:riv_corner_radius_top_left="4dp"
             app:riv_corner_radius_top_right="4dp"
-            android:layout_height="400dp"
+            android:layout_height="@dimen/pet_swipecard_image_height"
             android:transitionName="details"
             android:scaleType="centerCrop"
             android:id="@+id/image_pet"/>

--- a/app/src/main/res/layout/item_swipeable_card.xml
+++ b/app/src/main/res/layout/item_swipeable_card.xml
@@ -1,38 +1,71 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
-    android:background="@drawable/shape"
     android:gravity="center_horizontal"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="match_parent">
+
+    <FrameLayout
+        android:id="@+id/swipe_card_background"
+        android:layout_width="match_parent"
+        android:layout_height="470dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginBottom="12dp"
+            android:layout_marginLeft="16dp"
+            android:layout_marginRight="16dp"
+            android:background="@drawable/shape_2"
+            android:gravity="center_horizontal"
+            android:orientation="vertical" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginBottom="16dp"
+            android:layout_marginLeft="8dp"
+            android:layout_marginRight="8dp"
+            android:background="@drawable/shape1"
+            android:gravity="center_horizontal"
+            android:orientation="vertical" />
+
+    </FrameLayout>
 
     <RelativeLayout
+        android:background="@drawable/shape"
+        android:gravity="top|center_horizontal"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="450dp">
 
-        <ImageView
+        <com.makeramen.roundedimageview.RoundedImageView
+            xmlns:app="http://schemas.android.com/apk/res-auto"
             android:layout_width="match_parent"
+            android:layout_marginTop="2dp"
+            android:layout_marginLeft="2dp"
+            android:layout_marginRight="2dp"
+            app:riv_corner_radius_top_left="4dp"
+            app:riv_corner_radius_top_right="4dp"
             android:layout_height="400dp"
             android:transitionName="details"
             android:scaleType="centerCrop"
             android:id="@+id/image_pet"/>
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_below="@id/image_pet"
-                android:layout_alignParentLeft="true"
-                android:text="Pet Name"
-                style="@style/HeaderFont"
-                android:id="@+id/text_pet_name"/>
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/image_pet"
+            android:layout_alignParentLeft="true"
+            android:text="Pet Name"
+            style="@style/HeaderFont"
+            android:id="@+id/text_pet_name"/>
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentRight="true"
-                style="@style/HeaderFont"
-                android:layout_below="@id/image_pet"
-                android:id="@+id/text_pet_gender"/>
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentRight="true"
+            style="@style/HeaderFont"
+            android:layout_below="@id/image_pet"
+            android:id="@+id/text_pet_gender"/>
     </RelativeLayout>
 
     <View

--- a/app/src/main/res/layout/item_swipeable_card.xml
+++ b/app/src/main/res/layout/item_swipeable_card.xml
@@ -12,7 +12,7 @@
 
         <ImageView
             android:layout_width="match_parent"
-            android:layout_height="450dp"
+            android:layout_height="400dp"
             android:transitionName="details"
             android:scaleType="centerCrop"
             android:id="@+id/image_pet"/>

--- a/app/src/main/res/layout/pet_favorites_items.xml
+++ b/app/src/main/res/layout/pet_favorites_items.xml
@@ -5,15 +5,20 @@
     android:padding="8dp"
     android:layout_height="wrap_content">
 
-    <de.hdodenhof.circleimageview.CircleImageView
+    <com.makeramen.roundedimageview.RoundedImageView
         xmlns:app="http://schemas.android.com/apk/res-auto"
+        app:riv_corner_radius="30dp"
+        app:riv_border_width="0dp"
+        app:riv_oval="true"
         android:transitionName="details"
         android:layout_alignParentTop="true"
         android:layout_alignParentStart="true"
         android:layout_alignParentLeft="true"
         android:scaleType="centerCrop"
-        android:layout_width="96dp"
-        android:layout_height="96dp"
+        android:minHeight="@dimen/pet_favorites_profile_pic_height"
+        android:minWidth="@dimen/pet_favorites_profile_pic_width"
+        android:layout_width="@dimen/pet_favorites_profile_pic_width"
+        android:layout_height="@dimen/pet_favorites_profile_pic_height"
         android:id="@+id/petFavImage"/>
 
     <TextView

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -10,5 +10,5 @@
     <color name="icons">#FFFFFF</color>
     <color name="divider">#B6B6B6</color>
 
-    <item name="blue" type="color">#FF33B5E5</item>
+    <color name="swipe_card_border_color">#EFEFEF</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -9,4 +9,9 @@
     <dimen name="pet_favorites_profile_pic_width">96dp</dimen>
     <dimen name="pet_favorites_profile_pic_height">96dp</dimen>
 
+    <!-- Swipe Card Dimensions -->
+    <dimen name="pet_swipecard_image_height">400dp</dimen>
+    <dimen name="pet_swipecard_height">450dp</dimen>
+    <dimen name="pet_swipecard_frame_height">470dp</dimen>
+    
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -6,5 +6,7 @@
     <dimen name="fab_margin">16dp</dimen>
     <dimen name="name_font_size">16sp</dimen>
     <dimen name="pet_details_image_height">300dp</dimen>
+    <dimen name="pet_favorites_profile_pic_width">96dp</dimen>
+    <dimen name="pet_favorites_profile_pic_height">96dp</dimen>
 
 </resources>


### PR DESCRIPTION
@cbaja @scottrichards 

Issue #107 - Make our card view look like an actual deck of cards like Tinder
Issue #96 - Add padding around the browse card

I used Tinder as a reference for the card framing and frame border colors. I also rounded the right and left corners of the pet image in the swipe card to match Tinder.

The text labels for pet name and gender lost their padding. I thought I'd leave that alone since we already have another ticket to make that look nicer.

![swipecard](https://cloud.githubusercontent.com/assets/1521460/13802272/620c5914-eaf7-11e5-924b-1edb21b596a5.gif)
