### PR TITLE
Issue #98 - The z-index for the swipe card should be above everything else and should never get clipped

### DIFF
--- a/app/src/main/res/layout/content_pet_browser.xml
+++ b/app/src/main/res/layout/content_pet_browser.xml
@@ -12,7 +12,7 @@
 
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:id="@+id/layout_swipeable_pets_fragment_placeholder"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_swipeable_pets.xml
+++ b/app/src/main/res/layout/fragment_swipeable_pets.xml
@@ -1,7 +1,8 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:clipChildren="false"
     tools:context=".fragments.SwipeablePetsFragment"
     >
 
@@ -23,21 +24,10 @@
             />
     </LinearLayout>
 
-    <com.lorentzos.flingswipe.SwipeFlingAdapterView
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        android:layout_width="match_parent"
-        android:layout_height="500dp"
-        android:id="@+id/card_view"
-        app:rotation_degrees="16"
-        app:max_visible="4"
-        app:min_adapter_stack="6" />
-
-
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center_horizontal"
-        android:layout_below="@id/card_view">
+        android:layout_height="match_parent"
+        android:gravity="bottom|center_horizontal">
 
         <Button
             android:layout_width="wrap_content"
@@ -59,4 +49,14 @@
 
     </LinearLayout>
 
-</RelativeLayout>
+    <com.lorentzos.flingswipe.SwipeFlingAdapterView
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="500dp"
+        android:gravity="top|center_horizontal"
+        android:id="@+id/card_view"
+        app:rotation_degrees="16"
+        app:max_visible="4"
+        app:min_adapter_stack="6" />
+
+</FrameLayout>


### PR DESCRIPTION
@scottrichards @cbaja 

This pull request looks bigger than it is because it has everything from PR #109 as well. This change prevents the swipe card from being clipped and it uses a frame layout to give it a higher z-index than the like/not like buttons.

![clipping](https://cloud.githubusercontent.com/assets/1521460/13802686/78fb680a-eafb-11e5-94bb-3dafe7378a46.gif)
