### PR TITLE
Issue #113 - Keep all our activities in portrait mode only

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
         <activity
             android:name=".activities.PetBrowserActivity"
             android:label="@string/app_name"
+            android:screenOrientation="portrait"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
@@ -45,15 +46,18 @@
         <activity
             android:name=".activities.PetDetailsActivity"
             android:label=""
+            android:screenOrientation="portrait"
             android:theme="@style/AppTheme.NoActionBar">
         </activity>
         <activity
             android:name=".activities.PetFavoritesActivity"
             android:label="@string/title_activity_pet_favorites"
+            android:screenOrientation="portrait"
             android:theme="@style/AppTheme.NoActionBar">
         </activity>
         <activity
             android:name=".activities.PetSearchFilterActivity"
+            android:screenOrientation="portrait"
             android:label="@string/title_activity_pet_search_filter"
             android:theme="@style/AppTheme.NoActionBar">
         </activity>


### PR DESCRIPTION
Pretty straight forward. Just mark each activity as portrait only in our Android Manifest file.
